### PR TITLE
fix: sign published tags and commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,13 @@ jobs:
           full_version: ${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}
           tag_name: ${{ steps.release.outputs.tag_name }}
         run: |
+          gpg --allow-secret-key-import --import <<< "${{ secrets.PRIVATE_SIGNING_KEY }}"
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config commit.gpgsign true
+          git config tag.gpgsign true
+          git config --global user.name ueokande
+          git config --global user.email ueokande@i-beam.org
+          git config --global user.signingkey 7F94715D031FDE95
 
           git add .
           git commit --allow-empty --message "Release v${full_version} at ${GITHUB_SHA}"


### PR DESCRIPTION
Sign published branch (`latest`) and tags (`v1`, `v1.0`, and `v1.0.0`) and show "Verified" badge on the GitHub. The key is from the maintainer's registered GPG key. 