### PR TITLE
feat: bump runtime node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -9,14 +9,12 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@types/node": "^20.3.0",
-    "@types/node-fetch": "^2.6.4",
     "open": "^9.1.0"
   },
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@vercel/ncc": "^0.36.1",
     "googleapis": "^120.0.0",
-    "node-fetch": "^2",
     "typescript": "^5.0.4"
   },
   "scripts": {

--- a/src/cws.ts
+++ b/src/cws.ts
@@ -1,7 +1,5 @@
 import type { ReadStream } from "node:fs";
 import { google } from "googleapis";
-import fetch from "node-fetch";
-import type { BodyInit } from "node-fetch";
 
 type UploadState = "FAILURE" | "IN_PROGRESS" | "NOT_FOUND" | "SUCCESS";
 
@@ -82,7 +80,7 @@ export class CWSClient {
   private async proceed<T>(
     method: string,
     path: string,
-    body?: BodyInit,
+    body?: ReadStream,
   ): Promise<T> {
     await this.getAccessToken();
 


### PR DESCRIPTION
Bump runtime version to node 20 and use native [fetch()](https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#fetch) in Node.js.